### PR TITLE
Add tx_fee

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -262,6 +262,7 @@ if (!csv_os->is_open())
        << "Payment_id" << "Out_idx" << "Amount"
        << "Output_pub_key" << "Output_key_img"
        << "Output_spend"
+       << "Tx_fee"
        << NEWLINE;
 
 

--- a/src/tx_details.cpp
+++ b/src/tx_details.cpp
@@ -457,6 +457,7 @@ operator<<(csv::ofstream& ostm, const xmreg::transfer_details& td)
     ostm << out_pk_str.substr(1, out_pk_str.length()-2);
     ostm << key_img.substr(1, out_pk_str.length()-2);
     ostm << td.m_spent;
+    ostm << td.m_tx.rct_signatures.txnFee;
 
     return ostm;
 }


### PR DESCRIPTION
I added transaction fee to the list of exported the values.

I'm not sure if you'd prefer keeping the column as I did (as the last one), in order not to mess up other people's column number expectations, or to cluster the new column together with other `tx_` columns earlier.